### PR TITLE
Update NFT_TweakScale.cfg

### DIFF
--- a/Gamedata/TweakScale/NFT_TweakScale.cfg
+++ b/Gamedata/TweakScale/NFT_TweakScale.cfg
@@ -98,7 +98,7 @@
 		defaultScale = 2.5
 	}
 }
-@PART[trusslrg_hollow] // Modular Octo-Girder Collector's Hollow Edition
+@PART[trusslrg-hollow] // Modular Octo-Girder Collector's Hollow Edition
 {
 	MODULE
 	{
@@ -143,8 +143,15 @@
 		defaultScale = 2.5
 	}
 }
-
-
+@PART[trusslrg-adapter] // Adapter - 2.5m to Large Truss
+{
+	MODULE
+	{
+		name = TweakScale
+		type = stack
+		defaultScale = 2.5
+	}
+}
 @PART[trusslrg-adapter-25] // Octo-Girder Adapter
 {
 	MODULE


### PR DESCRIPTION
Fixed trusslrg-hollow, was using an underscore instead of a dash, causing it not to be scaled. 

Added Adapter - 2.5m to Large Truss, which was missing from the file.
