### PR TITLE
Update KOSMOS_TweakScale.cfg

### DIFF
--- a/Gamedata/TweakScale/KOSMOS_TweakScale.cfg
+++ b/Gamedata/TweakScale/KOSMOS_TweakScale.cfg
@@ -126,7 +126,7 @@ SCALETYPE
 	{
 		name = TweakScale
 		type = KOSMOS_stack
-		defaultScale = 1.0
+		defaultScale = 1.25
 	}
 }
 @PART[Kosmos_Balka_PanelBlock1_Single] // Balka Solar Wing Singular
@@ -135,7 +135,7 @@ SCALETYPE
 	{
 		name = TweakScale
 		type = KOSMOS_stack
-		defaultScale = 1.0
+		defaultScale = 1.25
 	}
 }
 @PART[Kosmos_Salyut_Solar_Array] // Salyut Solar Array
@@ -168,7 +168,7 @@ SCALETYPE
 	{
 		name = TweakScale
 		type = KOSMOS_stack
-		defaultScale = 1.0
+		defaultScale = 1.25
 	}
 }
 @PART[Kosmos_Angara_RD-0146] // RD-0146
@@ -177,7 +177,7 @@ SCALETYPE
 	{
 		name = TweakScale
 		type = KOSMOS_stack
-		defaultScale = 1.0
+		defaultScale = 1.25
 	}
 }
 @PART[Kosmos_Angara_RD-275K] // RD-275K
@@ -186,7 +186,7 @@ SCALETYPE
 	{
 		name = TweakScale
 		type = KOSMOS_stack
-		defaultScale = 1.0
+		defaultScale = 1.25
 	}
 }
 @PART[Kosmos_Angara_RD-33NK] // RD-33NK
@@ -195,7 +195,7 @@ SCALETYPE
 	{
 		name = TweakScale
 		type = KOSMOS_stack
-		defaultScale = 1.0
+		defaultScale = 1.25
 	}
 }
 @PART[Kosmos_Balka_1_Skeleton_RCS_Storage] // Balka 1m RCS Truss Block
@@ -213,7 +213,7 @@ SCALETYPE
 	{
 		name = TweakScale
 		type = KOSMOS_stack
-		defaultScale = 1.0
+		defaultScale = 1.25
 	}
 }
 @PART[Kosmos_TKS_RD-0225_Engine] // TKS RD-0225 Monopropellant Engine
@@ -495,7 +495,7 @@ SCALETYPE
 	{
 		name = TweakScale
 		type = KOSMOS_stack
-		defaultScale = 1.0
+		defaultScale = 1.25
 	}
 }
 @PART[Kosmos_Balka_1_Skeleton] // Balka 1m Truss Block
@@ -504,7 +504,7 @@ SCALETYPE
 	{
 		name = TweakScale
 		type = KOSMOS_stack
-		defaultScale = 1.0
+		defaultScale = 1.25
 	}
 }
 @PART[Kosmos_Berthing_Node_Hexaway] // Docking Node
@@ -513,7 +513,7 @@ SCALETYPE
 	{
 		name = TweakScale
 		type = KOSMOS_stack
-		defaultScale = 1.0
+		defaultScale = 1.25
 	}
 }
 @PART[Kosmos_Berthing_Node_Single_Side] // Radial Docking Node
@@ -522,7 +522,7 @@ SCALETYPE
 	{
 		name = TweakScale
 		type = KOSMOS_stack
-		defaultScale = 1.0
+		defaultScale = 1.25
 	}
 }
 @PART[Kosmos_Salyut_body_1.5] // Salyut 1.5m Body Section 
@@ -585,7 +585,7 @@ SCALETYPE
 	{
 		name = TweakScale
 		type = KOSMOS_stack
-		defaultScale = 1.0
+		defaultScale = 1.25
 	}
 }
 @PART[Kosmos_Common_LED_Flood_Light] // LED Flood Light


### PR DESCRIPTION
Updated KOSMOS engines built for size=1 default (1.25m)
Updated KOSMOS Balka tunnels built for size=1 default (1.25m)
Updated KOSMOS Solar Wings built for size=1 default (1.25m)
