### PR TITLE
Fixed node size scaling with tech restrictions

### DIFF
--- a/Scale.cs
+++ b/Scale.cs
@@ -329,7 +329,7 @@ namespace TweakScale
             	}
             	else
             	{
-                    node.size = (int)(baseNode.size + (tweakName - Tools.ClosestIndex(defaultScale, config.scaleFactors)) / (float)config.scaleFactors.Length * 5);
+                    node.size = (int)(baseNode.size + (Tools.ClosestIndex(tweakScale, config.allScaleFactors) - Tools.ClosestIndex(defaultScale, config.allScaleFactors)) / (float)config.allScaleFactors.Length * 5);
                 }
             }
             if (node.size < 0)


### PR DESCRIPTION
When not all of the potential scales have been unlocked in the tech tree
incorrect node sizes were being selected for use.

This seems to fix the problem, however I didn't look deeply enough to fully understand the maths this line is doing, so please double check the change makes sense.
