### PR TITLE
B9 Precoolers fix

### DIFF
--- a/Gamedata/TweakScale/B9_TweakScale.cfg
+++ b/Gamedata/TweakScale/B9_TweakScale.cfg
@@ -239,15 +239,16 @@
 		defaultScale = 1.25
 	}
 }
-@PART[B9_Engine_SABRE_Intake_S] // SABRE S Intake
-{
-	MODULE
-	{
-		name = TweakScale
-		type = stack
-		defaultScale = 1.25
-	}
-}
+//@PART[B9_Engine_SABRE_Intake_S] // SABRE S Intake
+//{
+//	MODULE
+//	{
+//		name = TweakScale
+//		type = stack
+//		defaultScale = 1.25
+//	}
+//}
+
 @PART[B9_Engine_SABRE_S] // SABRE S Engine
 {
 	MODULE
@@ -257,15 +258,15 @@
 		defaultScale = 1.25
 	}
 }
-@PART[B9_Engine_SABRE_S_Body] // SABRE S Precooler
-{
-	MODULE
-	{
-		name = TweakScale
-		type = stack
-		defaultScale = 1.25
-	}
-}
+//@PART[B9_Engine_SABRE_S_Body] // SABRE S Precooler
+//{
+//	MODULE
+//	{
+//		name = TweakScale
+//		type = stack
+//		defaultScale = 1.25
+//	}
+//}
 @PART[B9_Engine_VA1] // VA1 VTOL Jet Engine
 {
 	MODULE
@@ -347,15 +348,15 @@
 		defaultScale = 2.5
 	}
 }
-@PART[B9_Engine_SABRE_Intake_M] // SABRE M Intake
-{
-	MODULE
-	{
-		name = TweakScale
-		type = stack
-		defaultScale = 2.5
-	}
-}
+//@PART[B9_Engine_SABRE_Intake_M] // SABRE M Intake
+//{
+//	MODULE
+//	{
+//		name = TweakScale
+//		type = stack
+//		defaultScale = 2.5
+//	}
+//}
 @PART[B9_Engine_SABRE_M] // SABRE M Engine
 {
 	MODULE
@@ -365,15 +366,15 @@
 		defaultScale = 2.5
 	}
 }
-@PART[B9_Engine_SABRE_M_Body] // SABRE M Precooler
-{
-	MODULE
-	{
-		name = TweakScale
-		type = stack
-		defaultScale = 2.5
-	}
-}
+//@PART[B9_Engine_SABRE_M_Body] // SABRE M Precooler
+//{
+//	MODULE
+//	{
+//		name = TweakScale
+//		type = stack
+//		defaultScale = 2.5
+//	}
+//}
 
 @PART[B9_Aero_AirBrake_Surface] // Surface Mounted Air Brake
 {


### PR DESCRIPTION
Trying to attach a sabre intake to a precooler when using B9 causes an endless stream of null reference expeditions and stack overflows, causing many issues in the SPH (Parts not attaching; parts getting stuck to mouse cursors; unable to leave SPH either via exit or launch buttons or the menu; eventual lockup; other major glitches). 
Note that this is with other mods installed, I suspect that there is some KSP Interstellar shenanigans involved with the precoolers in some way.

These issues where fixed by removing/commenting out b9 sabre precoolers and intakes.
I have commented out the sabre precoolers and intakes.
