### PR TITLE
updated scale exponents for KSP Interstellar reactors

### DIFF
--- a/GameData/TweakScale/ScaleExponents.cfg
+++ b/GameData/TweakScale/ScaleExponents.cfg
@@ -4,10 +4,10 @@ TWEAKSCALEEXPONENTS
     breakingForce = 2
     breakingTorque = 2
     buoyancy = 3
-    crashTolerance = 1
+    crashTolerance = -0.2
     explosionPotential = 3
     maxTemp = 1
-    mass = 3
+    mass = 2.5
     
     Resources
     {
@@ -163,17 +163,17 @@ TWEAKSCALEEXPONENTS
 {
     name = ModuleReactionWheel
 
-    PitchTorque = 3
-    YawTorque = 3
-    RollTorque = 3
+    PitchTorque = 2.5
+    YawTorque = 2.5
+    RollTorque = 2.5
 }
 
 TWEAKSCALEEXPONENTS
 {
     name = ModuleEngines
     
-    minThrust = 2
-    maxThrust = 2
+    minThrust = 2.6
+    maxThrust = 2.6
     heatProduction = 1
 }
 
@@ -181,8 +181,8 @@ TWEAKSCALEEXPONENTS
 {
     name = ModuleEnginesFX
     
-    minThrust = 2
-    maxThrust = 2
+    minThrust = 2.2
+    maxThrust = 2.2
     heatProduction = 1
 }
 
@@ -204,7 +204,7 @@ TWEAKSCALEEXPONENTS
 {
     name = ModuleResourceIntake
     
-    area = 2
+    area = 2.2
 }
 
 
@@ -275,64 +275,51 @@ TWEAKSCALEEXPONENTS
 {
     name = FNGenerator
     radius = 1
-    maxThermalPower = 3
+    maxThermalPower = 2.5
 }
 
 TWEAKSCALEEXPONENTS
 {
     name = FNAntimatterReactor
     radius = 1
-	ReactorTemp = 1.16
+	ReactorTemp = 1.10
 	PowerOutput = 3
-	upgradedReactorTemp = 1.55
-	upgradedPowerOutput = 3
+	upgradedReactorTemp = 1.20
+	upgradedPowerOutput = 3.3
 }
 
 TWEAKSCALEEXPONENTS
 {
     name = InterstellarFissionMSRGC
     radius = 1
-    PowerOutput = 4.4
-	upgradedPowerOutput = 4.4
+    PowerOutput = 2.6
+	upgradedPowerOutput = 3
 }
 
 TWEAKSCALEEXPONENTS
 {
     name = InterstellarFissionPBDP
     radius = 1
-    PowerOutput = 3
+    PowerOutput = 2.6
 	upgradedPowerOutput = 3
-	powerRequirements = 3
 }
 
 TWEAKSCALEEXPONENTS
 {
     name = InterstellarInertialConfinementReactor
     radius = 1
-    PowerOutput = 3.18
-	upgradedPowerOutput = 3.18
-}
-
-TWEAKSCALEEXPONENTS
-{
-    name = FNFusionReactor
-    radius = 1;
-    ThermalPower = 3;
-    resourceRate = 3;
-    upgradedThermalPower = 3;
-    upgradedResourceRate = 3;
-    powerRequirements = 3;
+    PowerOutput = 2.8
+	upgradedPowerOutput = 3.2
+	powerRequirements = 3
 }
 
 TWEAKSCALEEXPONENTS
 {
     name = InterstellarTokamakFusionReator
-    radius = 1;
-    PowerOutput = 5.13;
-    resourceRate = 5.13;
-    upgradedThermalPower = 3;
-    upgradedResourceRate = 3;
-    powerRequirements = 3;
+    radius = 1
+    PowerOutput = 2.8
+	upgradedPowerOutput = 3.2
+    powerRequirements = 3
 }
 
 TWEAKSCALEEXPONENTS


### PR DESCRIPTION
The new ScaleExponents.cfg file is an edited .cfg from v1.50 - 2014-12-24 TweakScale release.
I've changed deprecated module parameters of reactors, so now their power scales correctly.
